### PR TITLE
Added SetPriority API to designate Android's Alert Builder's Priority

### DIFF
--- a/Plugin.Notifications.Abstractions/AbstractNotificationsImpl.cs
+++ b/Plugin.Notifications.Abstractions/AbstractNotificationsImpl.cs
@@ -7,7 +7,7 @@ namespace Plugin.Notifications
 {
 
     public abstract class AbstractNotificationsImpl : INotifications
-    {
+    {        
         public abstract Task Cancel(int notificationId);
         public abstract Task Send(Notification notification);
         public abstract Task<IEnumerable<Notification>> GetScheduledNotifications();
@@ -24,6 +24,11 @@ namespace Plugin.Notifications
             {
                 await this.Cancel(notification.Id.Value);
             }
+        }
+
+        public virtual void SetPriority(int priority)
+        {
+            // left empty by design since this is really only for android
         }
     }
 }

--- a/Plugin.Notifications.Abstractions/INotifications.cs
+++ b/Plugin.Notifications.Abstractions/INotifications.cs
@@ -61,5 +61,11 @@ namespace Plugin.Notifications
         /// </summary>
         /// <param name="ms"></param>
         void Vibrate(int ms = 300);
+
+        /// <summary>
+        /// The priority of the notification. Only applies to Android
+        /// </summary>
+        /// <param name="priority"></param>
+        void SetPriority(int priority);
     }
 }

--- a/Plugin.Notifications.Android/NotificationsImpl.cs
+++ b/Plugin.Notifications.Android/NotificationsImpl.cs
@@ -11,6 +11,7 @@ namespace Plugin.Notifications
 {
     public class NotificationsImpl : AbstractNotificationsImpl
     {
+        private int? priority = null;
         readonly AlarmManager alarmManager;
         public static int AppIconResourceId { get; set; }
 
@@ -61,6 +62,7 @@ namespace Plugin.Notifications
                     .SetContentTitle(notification.Title)
                     .SetContentText(notification.Message)
                     .SetSmallIcon(AppIconResourceId)
+                    .SetPriority(priority.HasValue ? priority.Value : NotificationCompat.PriorityDefault)
                     .SetContentIntent(TaskStackBuilder
                         .Create(Application.Context)
                         .AddNextIntent(launchIntent)
@@ -149,6 +151,11 @@ namespace Plugin.Notifications
 
                 vibrate.Vibrate(ms);
             }
+        }
+
+        public override void SetPriority(int priority)
+        {
+            this.priority = priority;
         }
 
 


### PR DESCRIPTION
This is a really cool plugin that you have created and it has a bunch of good features. I needed to fork it for a project and wanted to give back my contribution for the community.

I added a SetPriority API on the INotification. This allows you to designate a priority that will be used for displaying the notification on an Android Device. This API was added to the INotification for simplicity and when it is invoked on other platforms the method is left empty by design.  I did think about creating a static priority on the Android implementation but after getting it working it appeared too messy for a consumer to use. They would have to create a special android implementation of their code to get access to the android object. So I landed at this solution of adding the API onto the INotification

**Usage**

```c#
var notification = CrossNotifications.Current;
notification.SetPriority(2);
await notification.Send(new Notification
{
    Title = "Demo",
    Message = "This is a demo notification message"
});
```