### PR TITLE
[dev][ios] Instant notifications weren't working & trap permission request errors

### DIFF
--- a/Plugin.Notifications/Platforms/iOS/NotificationManagerImpl.cs
+++ b/Plugin.Notifications/Platforms/iOS/NotificationManagerImpl.cs
@@ -124,8 +124,14 @@ namespace Plugin.Notifications
                 UNAuthorizationOptions.Alert |
                 UNAuthorizationOptions.Badge |
                 UNAuthorizationOptions.Sound,
-                (approved, error) => tcs.TrySetResult(approved)
-            );
+                (approved, error) =>
+                {
+                    tcs.TrySetResult(approved);
+                    if (error is NSError)
+                    {
+                        tcs.SetException(new Exception(error.Description));
+                    }
+                });
             return tcs.Task;
         }
 

--- a/Plugin.Notifications/Platforms/iOS/NotificationManagerImpl.cs
+++ b/Plugin.Notifications/Platforms/iOS/NotificationManagerImpl.cs
@@ -80,13 +80,10 @@ namespace Plugin.Notifications
             if (!String.IsNullOrWhiteSpace(notification.Sound))
                 content.Sound = UNNotificationSound.GetSound(notification.Sound);
 
-            if (notification.Trigger == null)
-                notification.Trigger = CalendarNotificationTrigger.CreateFromSpecificDateTime(DateTime.Now);
-
             var request = UNNotificationRequest.FromIdentifier(
                 notification.Id.ToString(),
                 content,
-                notification.Trigger.ToNative()
+                notification.Trigger?.ToNative()
             );
             await UNUserNotificationCenter.Current.AddNotificationRequestAsync(request);
 


### PR DESCRIPTION
When I passed a null through the notification would display ok.
I also tried to pass back errors when attempting to gain notification permissions.